### PR TITLE
Ajoute un layout dédié à l'iframe et un middleware pour l'appliquer dynamiquement à la page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.1.0 [#21](https://github.com/betagouv/aides-simulateur-front/pull/21)
+
+* Ajout de fonctionnalité.
+* Détail :
+  * Applique un layout dédié aux pages exposées par `iframe` (sans header, footer ni padding)
+
 ### 0.0.2 [#13](https://github.com/betagouv/aides-simulateur-front/pull/13)
 
 * Évolution technique.

--- a/client/layouts/iframe.vue
+++ b/client/layouts/iframe.vue
@@ -1,0 +1,9 @@
+<template>
+  <main
+    id="content"
+    role="main"
+    tabindex="0"
+  >
+    <slot />
+  </main>
+</template>

--- a/client/middleware/check-iframe-layout.ts
+++ b/client/middleware/check-iframe-layout.ts
@@ -1,0 +1,5 @@
+export default defineNuxtRouteMiddleware((to) => {
+  if (isIframeRoute(to)) {
+    return setPageLayout('iframe')
+  }
+})

--- a/client/pages/simulateurs/[simulateur_id].vue
+++ b/client/pages/simulateurs/[simulateur_id].vue
@@ -3,6 +3,10 @@ import { simulateurs, type Simulateur } from '@/data/simulateurs'
 
 definePageMeta({
   layout: 'default',
+  middleware: 'check-iframe-layout',
+  validate ({ params }) {
+    return simulateurs.some(s => s.id === params.simulateur_id)
+  }
 })
 
 const route = useRoute()

--- a/client/utils/is-iframe-route.ts
+++ b/client/utils/is-iframe-route.ts
@@ -1,0 +1,8 @@
+import type { RouteLocationNormalizedGeneric } from 'vue-router'
+
+export function isIframeRoute (route: RouteLocationNormalizedGeneric) {
+  return (
+    route.query.iframe === 'true'
+    || route.params.iframe === 'true'
+  )
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aides-simulateur-front",
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "engines": {
     "node": "22"
   },


### PR DESCRIPTION
En lien avec #8 et #15 cette pr propose d'appliquer le layout 'iframe' (sans header, footer ni padding) à une page dynamiquement, en vérifiant une ou plusieurs conditions

D'après [la doc de nuxt sur setPageLayout](https://nuxt.com/docs/api/utils/set-page-layout)