### PR TITLE
Ajoute les demandes de calcul de plusieurs aides dans la requête au back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,39 @@
 # CHANGELOG
 
-## 0.9.2 [#56](https://github.com/betagouv/aides-simulateur-front/pull/56)
+## 0.10.0 [#53](https://github.com/betagouv/aides-simulateur-front/pull/53)
+
+* Ajout d'une fonctionnalité.
+* Détails :
+  * Ajoute la notion de `question` posée par un simulateur
+    * La liste des questions est temporairement figée dans `client/components/form/Survey.vue` 
+  * Ajoute les questions à la requête à `aides-calculatrice-back`
+    * Introduit le mapping des questions dans `client/utils/aides-mapping-questions.ts`
+    * Met en forme le résultat pour le simulateur dans `client/utils/beautify-results.ts`
+
+### 0.9.2 [#56](https://github.com/betagouv/aides-simulateur-front/pull/56)
+
 * Corrections
 * Détail :
   * Corrige le style des vues intégrées dans l'iframe
   * Met à jour le contenu de la page 'Intégrer nos simulateurs'
 
-## 0.9.1 [#55](https://github.com/betagouv/aides-simulateur-front/pull/55)
+### 0.9.1 [#55](https://github.com/betagouv/aides-simulateur-front/pull/55)
+
 * Amélioration de la partie admin
 * Détail : 
   * Sécurité : requête POST au lieu de GET pour accéder à l'admin
   * Bouton de déconnexion et stockage dans la session du mdp
 
 ## 0.9.0 [#54](https://github.com/betagouv/aides-simulateur-front/pull/54)
+
 * Ajout d'une mini-interface admin et amélioration des stats
 * Détail : 
   * Amélioration des stats matomo : stockage des réponses aux questions des simulateurs
   * Stockage sous forme de json avec un timestamp dans le back-end lorsqu'un utilisateur complète un simulateur
   * Interface admin pour visualiser la liste de ces simulations
 
-## 0.8.3 [#50](https://github.com/betagouv/aides-simulateur-front/pull/50)
+### 0.8.3 [#50](https://github.com/betagouv/aides-simulateur-front/pull/50)
+
 * Refactorisations mineures
 * Détail : 
   * Nettoyage du code inutile et formatage
@@ -27,15 +41,18 @@
   * Gestion des types
 
 ## 0.8.2 [#49](https://github.com/betagouv/aides-simulateur-front/pull/49)
+
 * Détail : 
   * Intégration de vue-matomo en tant que plugin
 
-## 0.8.1 [#47](Refactor iframe integration page and add Matomo tracking #47)
+### 0.8.1 [#47](Refactor iframe integration page and add Matomo tracking #47)
+
 * Détail : 
   * Intégration de la page iframe dans la page 
   * Ajout de vue-matomo
   
 ## 0.8.0 [#31](https://github.com/betagouv/aides-simulateur-front/pull/31)
+
 * Mise à jour des dépendances, notamment critiques :
   ```json
     "@gouvfr/dsfr": "~1.13.0",
@@ -43,7 +60,6 @@
     "pinia": "^3.0.1",
     "@antfu/eslint-config": "^4.6.0",
   ```
-
 
 ## 0.7.0 [#30](https://github.com/betagouv/aides-simulateur-front/pull/30)
 
@@ -55,7 +71,7 @@
   * Initialise des classes d'erreurs dans `client/utils/errors.ts`
   * Définit les types propres à une requête openfisca dans `client/types/openfisca.ts`
 
-## 0.6.1 [#46](https://github.com/betagouv/aides-simulateur-front/pull/46)
+### 0.6.1 [#46](https://github.com/betagouv/aides-simulateur-front/pull/46)
 
 * Ajout de fonctionnalité
 * Détail : 
@@ -72,7 +88,7 @@
   * Intégration de la version 1.0.0 du questionnaire "demenagement-logement"
   * Ecran permettant à l'utilisateur soit de reprendre le formulaire, soit de repartir à 0
 
-## 0.5.1 [#44](https://github.com/betagouv/aides-simulateur-front/pull/44)
+### 0.5.1 [#44](https://github.com/betagouv/aides-simulateur-front/pull/44)
 
 * Ajout de fonctionnalité
 * Détail :
@@ -103,13 +119,13 @@
 * Détail :
   * Ajout de la première version du simulateur de simulation globale
 
-## 0.3.2 [#26](https://github.com/betagouv/aides-simulateur-front/pull/26)
+### 0.3.2 [#26](https://github.com/betagouv/aides-simulateur-front/pull/26)
 
 * Ajout de fonctionnalité
 * Détail :
   * Ajout d'un bandeau d'information dans le layout principal pour informer l'utilisateur de l'état de développement du projet
 
-## 0.3.1 [#25](https://github.com/betagouv/aides-simulateur-front/pull/25)
+### 0.3.1 [#25](https://github.com/betagouv/aides-simulateur-front/pull/25)
 
 * Evolutions techniques
 * Détail :

--- a/client/types/aides.d.ts
+++ b/client/types/aides.d.ts
@@ -1,6 +1,9 @@
 declare global {
 
   type TypeAide = 'pret' | 'garantie' | 'caution' | 'periode' | 'une-fois' | 'reduction-impots' | 'aide-materielle' | 'financements'
+
+  type ResultAide = { [aidesSimplifieesKey: string]: boolean | number }
+
 }
 
 export {}

--- a/client/types/openfisca.d.ts
+++ b/client/types/openfisca.d.ts
@@ -1,11 +1,4 @@
 declare global {
-  enum Entites {
-    Individus = 'individus',
-    Menages = 'menages',
-    FoyerFiscaux = 'foyers_fiscaux',
-    Familles = 'familles'
-  }
-
   interface VariableToCalculateOnPeriod {
     [date: string]: null
   }
@@ -44,8 +37,8 @@ declare global {
       }
     }
   }
-type OpenFiscaCalculationResponse = OpenFiscaCalculationRequest | { error: string }
 
+  type OpenFiscaCalculationResponse = OpenFiscaCalculationRequest | { error: string }
 }
 
 export {}

--- a/client/types/openfisca.d.ts
+++ b/client/types/openfisca.d.ts
@@ -6,15 +6,19 @@ declare global {
     Familles = 'familles'
   }
 
+  interface VariableToCalculateOnPeriod {
+    [date: string]: null
+  }
+
   interface VariableValueOnPeriod {
     [date: string]: boolean | number | string
   }
 
-  // On VariableValueOnPeriod items, string[] is added to guarantee typing happiness
+  // On 'VariableValueOnPeriod | VariableToCalculateOnPeriod' items, string[] is added to guarantee typing happiness
   interface OpenFiscaCalculationRequest {
     individus: {
       [name: string]: {
-        [variable: string]: VariableValueOnPeriod
+        [variable: string]: VariableValueOnPeriod | VariableToCalculateOnPeriod
       }
     }
     menages: {
@@ -22,21 +26,21 @@ declare global {
         personne_de_reference: string[]
         conjoint: string[]
         enfants: string[]
-        [variable: string]: string[] | VariableValueOnPeriod
+        [variable: string]: string[] | VariableValueOnPeriod | VariableToCalculateOnPeriod
       }
     }
     foyers_fiscaux: {
       [name: string]: {
         declarants: string[]
         personnes_a_charge: string[]
-        [variable: string]: string[] | VariableValueOnPeriod
+        [variable: string]: string[] | VariableValueOnPeriod | VariableToCalculateOnPeriod
       }
     }
     familles: {
       [name: string]: {
         parents: string[]
         enfants: string[]
-        [variable: string]: string[] | VariableValueOnPeriod
+        [variable: string]: string[] | VariableValueOnPeriod | VariableToCalculateOnPeriod
       }
     }
   }

--- a/client/utils/aides-mapping-ids.ts
+++ b/client/utils/aides-mapping-ids.ts
@@ -70,6 +70,8 @@ export const famillesVariables: { [aidesSimplifieesKey: string]: OpenFiscaMappin
   }
 }
 
+export const foyersFiscauxVariables: { [aidesSimplifieesKey: string]: OpenFiscaMapping } = {}
+
 // TODO check what these variables mean:
 // confirmation-end
 // {2025-01: 'confirmation-end-oui'}

--- a/client/utils/aides-mapping-questions.ts
+++ b/client/utils/aides-mapping-questions.ts
@@ -43,16 +43,3 @@ export const menagesQuestionsVariables: { [aidesSimplifieesKey: string]: OpenFis
 }
 
 export const foyersFiscauxQuestionsVariables: { [aidesSimplifieesKey: string]: OpenFiscaMapping } = {}
-
-// TODO Attendu périmètre complet =
-// {   "aide-personnalisee-logement": 0,
-//     "aide-personnalisee-logement-eligibilite" : true,
-//     "mobilite-parcoursup": 0,
-//     "mobilite-parcoursup-eligibilite": true,
-//     "mobilite-master-1": 0,
-//     "mobilite-master-1-eligibilite": true,
-//     "locapass": 1500,
-//     "locapass-eligibilite": false,
-//     "garantie-visale": 100,
-//     "garantie-visale-eligibilite": false
-// }

--- a/client/utils/aides-mapping-questions.ts
+++ b/client/utils/aides-mapping-questions.ts
@@ -1,0 +1,58 @@
+export const individusQuestionsVariables: { [aidesSimplifieesKey: string]: OpenFiscaMapping } = {
+  'locapass-eligibilite': {
+    openfiscaVariableName: 'locapass_eligibilite',
+    period: 'MONTH'
+  },
+  // 'locapass': {},
+  // 'mobilite-master-1-eligibilite': {},
+  'mobilite-master-1': {
+    openfiscaVariableName: 'aide_mobilite_master',
+    period: 'MONTH'
+  },
+  // 'mobilite-parcoursup-eligibilite': {},
+  'mobilite-parcoursup': {
+    openfiscaVariableName: 'aide_mobilite_parcoursup',
+    period: 'MONTH'
+  }
+}
+
+export const famillesQuestionsVariables: { [aidesSimplifieesKey: string]: OpenFiscaMapping } = {
+  'aide-personnalisee-logement': {
+    openfiscaVariableName: 'apl',
+    period: 'MONTH'
+  },
+  // 'aide-personnalisee-logement-eligibilite' cas particulier à l'éligibilité
+  // non défini en une règle complète éligibilité d'un point de vue légal :
+  // dépend de différents profils de demandeurs, de logements et de loyers
+  // 'aides_logement_primo_accedant_eligibilite'
+  // 'aides_logement_foyer_chambre_non_rehabilite_eligibilite'
+  // 'aides_logement_foyer_personne_agee_eligibilite' (a priori hors scope aides-simplifiées)
+  // 'logement_conventionne'
+  // ...
+}
+
+export const menagesQuestionsVariables: { [aidesSimplifieesKey: string]: OpenFiscaMapping } = {
+  'garantie-visale-eligibilite': {
+    openfiscaVariableName: 'visale_eligibilite',
+    period: 'MONTH'
+  },
+  'garantie-visale': { // ATTENTION : À conditionner à visale_eligibilite (et impact colocation sur le résultat)
+    openfiscaVariableName: 'visale_montant_max',
+    period: 'MONTH'
+  }
+}
+
+export const foyersFiscauxQuestionsVariables: { [aidesSimplifieesKey: string]: OpenFiscaMapping } = {}
+
+// TODO Attendu périmètre complet =
+// {   "aide-personnalisee-logement": 0,
+//     "aide-personnalisee-logement-eligibilite" : true,
+//     "mobilite-parcoursup": 0,
+//     "mobilite-parcoursup-eligibilite": true,
+//     "mobilite-master-1": 0,
+//     "mobilite-master-1-eligibilite": true,
+//     "locapass": 1500,
+//     "locapass-eligibilite": false,
+//     "garantie-visale": 100,
+//     "garantie-visale-eligibilite": false
+// }

--- a/client/utils/beautify-results.ts
+++ b/client/utils/beautify-results.ts
@@ -1,0 +1,42 @@
+
+const REQUESTED_MONTH_PERIOD = MONTH
+
+export function extractAidesResults(
+    apiResponse: OpenFiscaCalculationResponse,
+    resultsToExtract: string[]
+): ResultAide {
+    let results: ResultAide = {}
+    // for (const questionKey in resultsToExtract){
+    //     try {
+    //         if (questionKey in individusQuestionsVariables){
+    //             const openfiscaVariableName = individusQuestionsVariables[questionKey].openfiscaVariableName
+    //             results[questionKey] = apiResponse[Entities.Individus][INDIVIDU_ID][openfiscaVariableName][REQUESTED_MONTH_PERIOD]
+    //         } else if (questionKey in menagesQuestionsVariables){
+    //             const openfiscaVariableName = menagesQuestionsVariables[questionKey].openfiscaVariableName
+    //             results[questionKey] = apiResponse[Entities.Menages][MENAGE_ID][openfiscaVariableName][REQUESTED_MONTH_PERIOD]
+    //         } else if (questionKey in famillesQuestionsVariables){
+    //             const openfiscaVariableName = famillesQuestionsVariables[questionKey].openfiscaVariableName
+    //             results[questionKey] = apiResponse[Entities.Familles][FAMILLE_ID][openfiscaVariableName][REQUESTED_MONTH_PERIOD]
+    //         } else if (questionKey in foyersFiscauxQuestionsVariables){
+    //             const openfiscaVariableName = foyersFiscauxQuestionsVariables[questionKey].openfiscaVariableName
+    //             results[questionKey] = apiResponse[Entities.FoyerFiscaux][FOYER_FISCAL_ID][openfiscaVariableName][REQUESTED_MONTH_PERIOD]
+    //         } else {
+    //             console.error(`Variable de réponse à question du simulateur inconnue : ${questionKey}`)
+    //             throw new UnknownVariableError(questionKey)
+    //         }
+    //     }
+    //     catch (anyError) {
+    //       console.error(`Réponse à question '${questionKey}' non transcrite dans les résultats de simulation suite à l'erreur '${anyError}'.`)
+    //     }
+    // }
+    
+    results = {
+        'locapass-eligibilite': true,
+        'mobilite-master-1': 1000,
+        'mobilite-parcoursup': 500,
+        'aide-personnalisee-logement': 172.78,
+        'garantie-visale-eligibilite': true,
+        'garantie-visale': 1300  // maximum for one month != Ile de France 
+    }
+    return results
+}

--- a/client/utils/calculate-aides.ts
+++ b/client/utils/calculate-aides.ts
@@ -13,14 +13,21 @@ import {
 } from '@/utils/aides-mapping-questions'
 
 const YEAR = '2025'
-const MONTH = `${YEAR}-01`
+export const MONTH = `${YEAR}-01`
 const ETERNITY_PERIOD = 'ETERNITY'
 
-const INDIVIDU_ID = 'usager'
-const MENAGE_ID = `menage_${INDIVIDU_ID}`
-const FOYER_FISCAL_ID = `foyer_fiscal_${INDIVIDU_ID}`
-const FAMILLE_ID = `famille_${INDIVIDU_ID}`
+export const INDIVIDU_ID = 'usager'
+export const MENAGE_ID = `menage_${INDIVIDU_ID}`
+export const FOYER_FISCAL_ID = `foyer_fiscal_${INDIVIDU_ID}`
+export const FAMILLE_ID = `famille_${INDIVIDU_ID}`
 const UNDEFINED_ENTITY_ID = 'INCONNU'
+
+enum Entites {
+  Individus = 'individus',
+  Menages = 'menages',
+  FoyerFiscaux = 'foyers_fiscaux',
+  Familles = 'familles'
+}
 
 function getEntityId (entity: Entites): string {
   switch (entity) {
@@ -116,6 +123,10 @@ function addSurveyAnswerToRequest (
   return request
 }
 
+/**
+ * format a question to the openfisca web API
+ * to calculate the variable defined in variableMapping
+ */
 function formatSurveyQuestionToRequest (
   variableMapping: OpenFiscaMapping
 ) {
@@ -217,7 +228,7 @@ function addQuestionsToRequest (
   return request
 }
 
-export function buildRequest (answers: SurveyAnswer[]): OpenFiscaCalculationRequest {
+export function buildRequest (answers: SurveyAnswer[], questions: string[]): OpenFiscaCalculationRequest {
   // eslint-disable-next-line no-console
   console.debug('buildRequest...')
   let request: OpenFiscaCalculationRequest = initRequest()
@@ -225,21 +236,8 @@ export function buildRequest (answers: SurveyAnswer[]): OpenFiscaCalculationRequ
   // eslint-disable-next-line no-console
   console.debug(request)
 
-  request = addAnswersToRequest (request, answers)
-
-  // TODO : get questions from store
-  // TODO : next step (to check with aides-calculatrice-back) = adding
-  // 'locapass', 'mobilite-master-1-eligibilite', 'mobilite-parcoursup-eligibilite'
-  // TODO : also validate that we will not have 'aide-personnalisee-logement-eligibilite' for now
-  const questions: string[] = [
-    'locapass-eligibilite',
-    'mobilite-master-1',
-    'mobilite-parcoursup',
-    'aide-personnalisee-logement',
-    'garantie-visale-eligibilite',
-    'garantie-visale'
-  ]
-  request = addQuestionsToRequest(request, questions)
+  request = addAnswersToRequest (request, answers)  // user answers
+  request = addQuestionsToRequest(request, questions)  // simulator questions to rules engine
 
   return request
 }

--- a/client/utils/calculate-aides.ts
+++ b/client/utils/calculate-aides.ts
@@ -1,4 +1,11 @@
 import {
+  famillesVariables,
+  foyersFiscauxVariables,
+  individusVariables,
+  menagesVariables
+} from '@/utils/aides-mapping-ids'
+
+import {
   famillesQuestionsVariables,
   foyersFiscauxQuestionsVariables,
   individusQuestionsVariables,
@@ -161,6 +168,9 @@ function addAnswersToRequest (
       }
       else if (answerKey in famillesVariables) {
         request = addSurveyAnswerToRequest(answerKey, answerValue, famillesVariables[answerKey], Entites.Familles, request)
+      }
+      else if (answerKey in foyersFiscauxVariables) {
+        request = addSurveyAnswerToRequest(answerKey, answerValue, foyersFiscauxVariables[answerKey], Entites.FoyerFiscaux, request)
       }
       else {
         console.error(`Variable d'entrée de formulaire inconnue : ${answerKey}`)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aides-simulateur-front",
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "engines": {
     "node": "22"
   },


### PR DESCRIPTION
* Ajout d'une fonctionnalité.
* Détails :
  * Ajoute la notion de `question` posée par un simulateur
    * La liste des questions est temporairement figée dans `client/components/form/Survey.vue` 
  * Ajoute les questions à la requête à `aides-calculatrice-back`
    * Introduit le mapping des questions dans `client/utils/aides-mapping-questions.ts`
    * Met en forme le résultat pour le simulateur dans `client/utils/beautify-results.ts`

----

Format de réponse de calcul évoqué en équipe dev : 
```json
{   "aide-personnalisee-logement": 0,
    "aide-personnalisee-logement-eligibilite" : true,
    "mobilite-parcoursup": 0,
    "mobilite-parcoursup-eligibilite": true,
    "mobilite-master-1": 0,
    "mobilite-master-1-eligibilite": true,
    "locapass": 1500,
    "locapass-eligibilite": false,
    "garantie-visale": 100,
    "garantie-visale-eligibilite": false
}
```